### PR TITLE
feat: allow cheats raw input to horizontally scroll for long lines

### DIFF
--- a/gbajs3/src/components/modals/cheats.tsx
+++ b/gbajs3/src/components/modals/cheats.tsx
@@ -223,6 +223,16 @@ export const CheatsModal = () => {
             fullWidth
             minRows={6}
             variant="outlined"
+            InputProps={{
+              sx: {
+                ['textarea']: {
+                  whiteSpace: 'pre',
+                  // see: https://github.com/mui/material-ui/issues/41490
+                  //      remove/refactor once resolved
+                  overflowX: 'auto !important'
+                }
+              }
+            }}
             helperText={errors?.rawCheats?.message}
             style={{ display: viewRawCheats ? 'block' : 'none' }}
             {...register('rawCheats')}


### PR DESCRIPTION
- see: https://github.com/mui/material-ui/issues/41490

- TODO: remove `!important` if there ends up being another way to accomplish this through css or other configuration methods