### PR TITLE
fix: control panel tour zindex on desktop

### DIFF
--- a/gbajs3/src/components/controls/control-panel.tsx
+++ b/gbajs3/src/components/controls/control-panel.tsx
@@ -396,7 +396,7 @@ export const ControlPanel = () => {
       <EmbeddedProductTour
         steps={tourSteps}
         completedProductTourStepName="hasCompletedControlPanelTour"
-        zIndex={0}
+        zIndex={isLargerThanPhone ? undefined : 0}
         renderWithoutDelay
         isNotInModal
       />


### PR DESCRIPTION
- could be hidden by the side bar menu at certain screen widths