### PR TITLE
staging deploy to ghp

### DIFF
--- a/.github/workflows/deploy-pages.workflow.yml
+++ b/.github/workflows/deploy-pages.workflow.yml
@@ -1,0 +1,28 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./gbajs3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: gbajs3
+          sparse-checkout-cone-mode: false
+
+      - id: build-publish
+        uses: bitovi/github-actions-react-to-github-pages@v1.2.3
+        with:
+          checkout: false


### PR DESCRIPTION
- attempting to try this out, it won't work unless the workflow file is present on the main branch

- will revert if unsuccessful

- TODO: pass client host from GitHub action secrets/env to the deploy job