### PR TITLE
refactor: virtual controls defaults

### DIFF
--- a/gbajs3/src/components/controls/virtual-controls.spec.tsx
+++ b/gbajs3/src/components/controls/virtual-controls.spec.tsx
@@ -3,10 +3,7 @@ import { userEvent } from '@testing-library/user-event';
 import * as toast from 'react-hot-toast';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  saveStateSlotLocalStorageKey,
-  virtualControlsLocalStorageKey
-} from './consts.tsx';
+import { saveStateSlotLocalStorageKey } from './consts.tsx';
 import { VirtualControls } from './virtual-controls.tsx';
 import { renderWithContext } from '../../../test/render-with-context.tsx';
 import { GbaDarkTheme } from '../../context/theme/theme.tsx';
@@ -66,11 +63,32 @@ describe('<VirtualControls />', () => {
   });
 
   describe('Additional Controls', () => {
-    beforeEach(() => {
-      localStorage.setItem(
-        virtualControlsLocalStorageKey,
-        '{"DPadAndButtons":true,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
-      );
+    it('renders no additional controls by default on desktop', () => {
+      vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+        matches: query === GbaDarkTheme.isLargerThanPhone,
+        media: '',
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true
+      }));
+
+      renderWithContext(<VirtualControls />);
+
+      expect(
+        screen.queryByLabelText('Quickreload Button')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Uploadsave Button')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Loadstate Button')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Savestate Buttonn')
+      ).not.toBeInTheDocument();
     });
 
     it('quick reloads game', async () => {

--- a/gbajs3/src/components/controls/virtual-controls.tsx
+++ b/gbajs3/src/components/controls/virtual-controls.tsx
@@ -70,10 +70,17 @@ export const VirtualControls = () => {
 
   if (!controlPanelBounds) return null;
 
-  const shouldShowVirtualButtonsAndDpad =
-    (areVirtualControlsEnabled?.DPadAndButtons === undefined &&
-      !isLargerThanPhone) ||
-    areVirtualControlsEnabled?.DPadAndButtons;
+  const shouldShowVirtualControl = (virtualControlEnabled?: boolean) => {
+    return (
+      (virtualControlEnabled === undefined && !isLargerThanPhone) ||
+      !!virtualControlEnabled
+    );
+  };
+
+  const shouldShowVirtualButtonsAndOpad = shouldShowVirtualControl(
+    areVirtualControlsEnabled?.OpadAndButtons
+  );
+
   const areNotificationsEnabled =
     areVirtualControlsEnabled?.NotificationsEnabled ?? true;
 
@@ -256,7 +263,7 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'a-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       keyId: 'B',
@@ -267,7 +274,7 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'b-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       keyId: 'START',
@@ -275,7 +282,7 @@ export const VirtualControls = () => {
       children: <VirtualButtonTextSmall>Start</VirtualButtonTextSmall>,
       initialPosition: initialPositionForKey('start-button'),
       keyName: 'start-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       keyId: 'SELECT',
@@ -283,7 +290,7 @@ export const VirtualControls = () => {
       children: <VirtualButtonTextSmall>Select</VirtualButtonTextSmall>,
       initialPosition: initialPositionForKey('select-button'),
       keyName: 'select-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       keyId: 'L',
@@ -291,7 +298,7 @@ export const VirtualControls = () => {
       children: <VirtualButtonTextSmall>L</VirtualButtonTextSmall>,
       initialPosition: initialPositionForKey('l-button'),
       keyName: 'l-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       keyId: 'R',
@@ -303,14 +310,13 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'r-button',
-      enabled: shouldShowVirtualButtonsAndDpad
+      enabled: shouldShowVirtualButtonsAndOpad
     },
     {
       children: <BiRefresh />,
       onClick: () => {
         emulator?.quickReload();
 
-        // TODO: is this the wrong indicator? maybe use isEmulatorRunning?
         if (!emulator?.getCurrentGameName() && areNotificationsEnabled)
           toast.error('Load a game to quick reload', {
             id: virtualControlToastId
@@ -319,7 +325,7 @@ export const VirtualControls = () => {
       width: 40,
       initialPosition: initialPositionForKey('quickreload-button'),
       keyName: 'quickreload-button',
-      enabled: areVirtualControlsEnabled?.QuickReload
+      enabled: shouldShowVirtualControl(areVirtualControlsEnabled?.QuickReload)
     },
     {
       children: <BiSolidCloudUpload />,
@@ -340,7 +346,9 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'uploadsave-button',
-      enabled: areVirtualControlsEnabled?.SendSaveToServer
+      enabled: shouldShowVirtualControl(
+        areVirtualControlsEnabled?.SendSaveToServer
+      )
     },
     {
       children: <BiSolidBookmark />,
@@ -360,7 +368,7 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'loadstate-button',
-      enabled: areVirtualControlsEnabled?.LoadState
+      enabled: shouldShowVirtualControl(areVirtualControlsEnabled?.LoadState)
     },
     {
       children: <BiSave />,
@@ -380,13 +388,13 @@ export const VirtualControls = () => {
         y: '0px'
       },
       keyName: 'savestate-button',
-      enabled: areVirtualControlsEnabled?.SaveState
+      enabled: shouldShowVirtualControl(areVirtualControlsEnabled?.SaveState)
     }
   ];
 
   return (
     <IconContext.Provider value={{ color: theme.pureWhite, size: '2em' }}>
-      {shouldShowVirtualButtonsAndDpad && (
+      {shouldShowVirtualButtonsAndOpad && (
         <OPad initialPosition={initialPositionForKey('o-pad')} />
       )}
       {virtualButtons.map((virtualButtonProps) => (

--- a/gbajs3/src/components/modals/controls/virtual-controls-form.spec.tsx
+++ b/gbajs3/src/components/modals/controls/virtual-controls-form.spec.tsx
@@ -50,7 +50,7 @@ describe('<VirtualControlsForm />', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith(
       virtualControlsLocalStorageKey,
-      '{"DPadAndButtons":true,"NotificationsEnabled":true,"SaveState":false,"LoadState":false,"QuickReload":false,"SendSaveToServer":false}'
+      '{"OpadAndButtons":true,"NotificationsEnabled":true,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
     );
   });
 
@@ -82,11 +82,11 @@ describe('<VirtualControlsForm />', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith(
       virtualControlsLocalStorageKey,
-      '{"DPadAndButtons":false,"NotificationsEnabled":false,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
+      '{"OpadAndButtons":false,"NotificationsEnabled":false,"SaveState":false,"LoadState":false,"QuickReload":false,"SendSaveToServer":false}'
     );
   });
 
-  it('DPadAndButtons is true by default on mobile resolutions', () => {
+  it('virtual controls true by default on mobile resolutions', () => {
     vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
       matches: query !== GbaDarkTheme.isLargerThanPhone,
       media: '',
@@ -100,15 +100,14 @@ describe('<VirtualControlsForm />', () => {
 
     renderWithContext(<VirtualControlsForm id="testId" />);
 
-    const dpadAndButtonsCheckbox = screen.getByLabelText(
-      'Virtual D-pad/Buttons'
-    );
-
-    expect(dpadAndButtonsCheckbox).toBeInTheDocument();
-    expect(dpadAndButtonsCheckbox).toBeChecked();
+    expect(screen.getByLabelText('Virtual D-pad/Buttons')).toBeChecked();
+    expect(screen.getByLabelText('Save State')).toBeChecked();
+    expect(screen.getByLabelText('Load State')).toBeChecked();
+    expect(screen.getByLabelText('Quick Reload')).toBeChecked();
+    expect(screen.getByLabelText('Send save to server')).toBeChecked();
   });
 
-  it('DPadAndButtons is false by default on desktop resolutions', () => {
+  it('virtual controls are false by default on desktop resolutions', () => {
     vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
       matches: query === GbaDarkTheme.isLargerThanPhone,
       media: '',
@@ -122,18 +121,17 @@ describe('<VirtualControlsForm />', () => {
 
     renderWithContext(<VirtualControlsForm id="testId" />);
 
-    const dpadAndButtonsCheckbox = screen.getByLabelText(
-      'Virtual D-pad/Buttons'
-    );
-
-    expect(dpadAndButtonsCheckbox).toBeInTheDocument();
-    expect(dpadAndButtonsCheckbox).not.toBeChecked();
+    expect(screen.getByLabelText('Virtual D-pad/Buttons')).not.toBeChecked();
+    expect(screen.getByLabelText('Save State')).not.toBeChecked();
+    expect(screen.getByLabelText('Load State')).not.toBeChecked();
+    expect(screen.getByLabelText('Quick Reload')).not.toBeChecked();
+    expect(screen.getByLabelText('Send save to server')).not.toBeChecked();
   });
 
   it('renders initial values from storage', () => {
     localStorage.setItem(
       virtualControlsLocalStorageKey,
-      '{"DPadAndButtons":false,"NotificationsEnabled":false,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
+      '{"OpadAndButtons":false,"NotificationsEnabled":false,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
     );
 
     renderWithContext(<VirtualControlsForm id="testId" />);

--- a/gbajs3/src/components/modals/controls/virtual-controls-form.spec.tsx
+++ b/gbajs3/src/components/modals/controls/virtual-controls-form.spec.tsx
@@ -50,7 +50,7 @@ describe('<VirtualControlsForm />', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith(
       virtualControlsLocalStorageKey,
-      '{"OpadAndButtons":true,"NotificationsEnabled":true,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
+      '{"OpadAndButtons":true,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true,"NotificationsEnabled":true}'
     );
   });
 
@@ -82,11 +82,11 @@ describe('<VirtualControlsForm />', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith(
       virtualControlsLocalStorageKey,
-      '{"OpadAndButtons":false,"NotificationsEnabled":false,"SaveState":false,"LoadState":false,"QuickReload":false,"SendSaveToServer":false}'
+      '{"OpadAndButtons":false,"SaveState":false,"LoadState":false,"QuickReload":false,"SendSaveToServer":false,"NotificationsEnabled":false}'
     );
   });
 
-  it('virtual controls true by default on mobile resolutions', () => {
+  it('virtual controls are true by default on mobile resolutions', () => {
     vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
       matches: query !== GbaDarkTheme.isLargerThanPhone,
       media: '',
@@ -131,7 +131,7 @@ describe('<VirtualControlsForm />', () => {
   it('renders initial values from storage', () => {
     localStorage.setItem(
       virtualControlsLocalStorageKey,
-      '{"OpadAndButtons":false,"NotificationsEnabled":false,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true}'
+      '{"OpadAndButtons":false,"SaveState":true,"LoadState":true,"QuickReload":true,"SendSaveToServer":true,"NotificationsEnabled":false}'
     );
 
     renderWithContext(<VirtualControlsForm id="testId" />);

--- a/gbajs3/src/components/modals/controls/virtual-controls-form.tsx
+++ b/gbajs3/src/components/modals/controls/virtual-controls-form.tsx
@@ -11,15 +11,6 @@ type VirtualControlsFormProps = {
   id: string;
 };
 
-type ControlsInputProps = {
-  OpadAndButtons: boolean;
-  SaveState: boolean;
-  LoadState: boolean;
-  QuickReload: boolean;
-  SendSaveToServer: boolean;
-  NotificationsEnabled: boolean;
-};
-
 export type AreVirtualControlsEnabledProps = {
   OpadAndButtons: boolean;
   SaveState: boolean;
@@ -28,6 +19,8 @@ export type AreVirtualControlsEnabledProps = {
   SendSaveToServer: boolean;
   NotificationsEnabled: boolean;
 };
+
+type ControlsInputProps = AreVirtualControlsEnabledProps;
 
 const StyledForm = styled.form`
   display: flex;
@@ -49,29 +42,15 @@ export const VirtualControlsForm = ({ id }: VirtualControlsFormProps) => {
     );
   };
 
-  const areVirtualControlsEnabledWithDefaults = Object.fromEntries(
-    Object.entries(
-      areVirtualControlsEnabled ?? {
-        OpadAndButtons: undefined,
-        NotificationsEnabled: undefined,
-        SaveState: undefined,
-        LoadState: undefined,
-        QuickReload: undefined,
-        SendSaveToServer: undefined
-      }
-    ).map(([key, value]) => {
-      return [
-        key,
-        key !== 'NotificationsEnabled'
-          ? shouldShowVirtualControl(value)
-          : value ?? true
-      ];
-    })
-  );
-
   const { register, handleSubmit, watch } = useForm<ControlsInputProps>({
-    values:
-      areVirtualControlsEnabledWithDefaults as AreVirtualControlsEnabledProps,
+    values: areVirtualControlsEnabled ?? {
+      OpadAndButtons: shouldShowVirtualControl(undefined),
+      SaveState: shouldShowVirtualControl(undefined),
+      LoadState: shouldShowVirtualControl(undefined),
+      QuickReload: shouldShowVirtualControl(undefined),
+      SendSaveToServer: shouldShowVirtualControl(undefined),
+      NotificationsEnabled: true
+    },
     resetOptions: {
       keepDirtyValues: true
     }

--- a/gbajs3/src/components/modals/controls/virtual-controls-form.tsx
+++ b/gbajs3/src/components/modals/controls/virtual-controls-form.tsx
@@ -1,6 +1,5 @@
 import { useMediaQuery } from '@mui/material';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { useEffect } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { styled, useTheme } from 'styled-components';
 
@@ -8,17 +7,12 @@ import { virtualControlsLocalStorageKey } from '../../controls/consts.tsx';
 import { ManagedCheckbox } from '../../shared/managed-checkbox.tsx';
 import { ManagedSwitch } from '../../shared/managed-switch.tsx';
 
-const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-`;
-
 type VirtualControlsFormProps = {
   id: string;
 };
 
 type ControlsInputProps = {
-  DPadAndButtons: boolean;
+  OpadAndButtons: boolean;
   SaveState: boolean;
   LoadState: boolean;
   QuickReload: boolean;
@@ -27,13 +21,18 @@ type ControlsInputProps = {
 };
 
 export type AreVirtualControlsEnabledProps = {
-  DPadAndButtons?: boolean;
-  SaveState?: boolean;
-  LoadState?: boolean;
-  QuickReload?: boolean;
-  SendSaveToServer?: boolean;
-  NotificationsEnabled?: boolean;
+  OpadAndButtons: boolean;
+  SaveState: boolean;
+  LoadState: boolean;
+  QuickReload: boolean;
+  SendSaveToServer: boolean;
+  NotificationsEnabled: boolean;
 };
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const VirtualControlsForm = ({ id }: VirtualControlsFormProps) => {
   const [areVirtualControlsEnabled, setAreVirtualControlsEnabled] =
@@ -42,24 +41,41 @@ export const VirtualControlsForm = ({ id }: VirtualControlsFormProps) => {
     );
   const theme = useTheme();
   const isLargerThanPhone = useMediaQuery(theme.isLargerThanPhone);
-  const areDPadAndButtonsEnabled =
-    areVirtualControlsEnabled?.DPadAndButtons ?? !isLargerThanPhone;
-  const areNotificationsEnabled =
-    areVirtualControlsEnabled?.NotificationsEnabled ?? true;
 
-  const { register, handleSubmit, setValue, watch } =
-    useForm<ControlsInputProps>({
-      defaultValues: {
-        ...areVirtualControlsEnabled,
-        DPadAndButtons: areDPadAndButtonsEnabled,
-        NotificationsEnabled: areNotificationsEnabled
+  const shouldShowVirtualControl = (virtualControlEnabled?: boolean) => {
+    return (
+      (virtualControlEnabled === undefined && !isLargerThanPhone) ||
+      !!virtualControlEnabled
+    );
+  };
+
+  const areVirtualControlsEnabledWithDefaults = Object.fromEntries(
+    Object.entries(
+      areVirtualControlsEnabled ?? {
+        OpadAndButtons: undefined,
+        NotificationsEnabled: undefined,
+        SaveState: undefined,
+        LoadState: undefined,
+        QuickReload: undefined,
+        SendSaveToServer: undefined
       }
-    });
+    ).map(([key, value]) => {
+      return [
+        key,
+        key !== 'NotificationsEnabled'
+          ? shouldShowVirtualControl(value)
+          : value ?? true
+      ];
+    })
+  );
 
-  useEffect(() => {
-    // DPadAndButtons is the only value that can dynamically change without user input
-    setValue('DPadAndButtons', areDPadAndButtonsEnabled);
-  }, [areDPadAndButtonsEnabled, setValue]);
+  const { register, handleSubmit, watch } = useForm<ControlsInputProps>({
+    values:
+      areVirtualControlsEnabledWithDefaults as AreVirtualControlsEnabledProps,
+    resetOptions: {
+      keepDirtyValues: true
+    }
+  });
 
   const onSubmit: SubmitHandler<ControlsInputProps> = async (formData) => {
     setAreVirtualControlsEnabled((prevState) => ({
@@ -76,8 +92,8 @@ export const VirtualControlsForm = ({ id }: VirtualControlsFormProps) => {
     >
       <ManagedCheckbox
         label="Virtual D-pad/Buttons"
-        watcher={watch('DPadAndButtons')}
-        registerProps={register('DPadAndButtons')}
+        watcher={watch('OpadAndButtons')}
+        registerProps={register('OpadAndButtons')}
       />
       <ManagedCheckbox
         label="Save State"


### PR DESCRIPTION
- show all additional controls on mobile resolutions by default

- default experience now matches readme screenshots