### PR TITLE
feat: update tour to state save/save state names must match rom

### DIFF
--- a/gbajs3/src/components/modals/upload-saves.spec.tsx
+++ b/gbajs3/src/components/modals/upload-saves.spec.tsx
@@ -148,6 +148,11 @@ describe('<UploadSavesModal />', () => {
     ).toBeInTheDocument();
     expect(
       await screen.findByText(
+        'The name of your files must match the name of your rom.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
         "Save and save state files should have an extension '.sav' or start with '.ss'."
       )
     ).toBeInTheDocument();
@@ -163,6 +168,11 @@ describe('<UploadSavesModal />', () => {
     expect(
       screen.getByText(
         'Use this area to drag and drop your save or save state files, or click to select files.'
+      )
+    ).toBeVisible();
+    expect(
+      await screen.findByText(
+        'The name of your files must match the name of your rom.'
       )
     ).toBeVisible();
     expect(

--- a/gbajs3/src/components/modals/upload-saves.tsx
+++ b/gbajs3/src/components/modals/upload-saves.tsx
@@ -56,6 +56,7 @@ export const UploadSavesModal = () => {
             Use this area to drag and drop your save or save state files, or
             click to select files.
           </p>
+          <p>The name of your files must match the name of your rom.</p>
           <p>
             Save and save state files should have an extension '.sav' or start
             with '.ss'.


### PR DESCRIPTION
### High Level Details

- adds tour text stating that the save/save state name must match the associated rom name

<img width="319" alt="Screenshot 2024-08-24 at 12 20 02 PM" src="https://github.com/user-attachments/assets/12cf5ee3-2266-4175-a0eb-5e9332129e4f">
