### PR TITLE
chore: update docker port mapping

### DIFF
--- a/gbajs3/docker-compose.yaml
+++ b/gbajs3/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
             args:
                 CLIENT_HOST: ${CLIENT_HOST}
         ports:
-            - "443:443"
-            - "80:80"
+            - 443:443
+            - 80:80
         environment:
             - CLIENT_HOST=${CLIENT_HOST}
         volumes:


### PR DESCRIPTION
- strings no longer seem to be necessary, updating to use integers