### PR TITLE
fix: remove coi service worker from coverage

### DIFF
--- a/gbajs3/vite.config.ts
+++ b/gbajs3/vite.config.ts
@@ -170,7 +170,8 @@ export default defineConfig(({ mode }) => {
           'test/**',
           'src/emulator/mgba/wasm/**',
           '**/*.d.ts',
-          '**/*eslint*'
+          '**/*eslint*',
+          '**/service-worker/**'
         ]
       }
     }


### PR DESCRIPTION
- not easily testable with unit tests in vitest