### PR TITLE
feat: hoist quick reload

### DIFF
--- a/gbajs3/src/components/controls/virtual-controls.spec.tsx
+++ b/gbajs3/src/components/controls/virtual-controls.spec.tsx
@@ -108,9 +108,10 @@ describe('<VirtualControls />', () => {
         } as GBAEmulator
       }));
 
-      vi.spyOn(quickReloadHooks, 'useQuickReload').mockReturnValue(
-        quickReloadSpy
-      );
+      vi.spyOn(quickReloadHooks, 'useQuickReload').mockImplementation(() => ({
+        quickReload: quickReloadSpy,
+        isQuickReloadAvailable: true
+      }));
 
       const toastErrorSpy = vi.spyOn(toast.default, 'error');
 
@@ -135,9 +136,10 @@ describe('<VirtualControls />', () => {
         } as GBAEmulator
       }));
 
-      vi.spyOn(quickReloadHooks, 'useQuickReload').mockReturnValue(
-        quickReloadSpy
-      );
+      vi.spyOn(quickReloadHooks, 'useQuickReload').mockImplementation(() => ({
+        quickReload: quickReloadSpy,
+        isQuickReloadAvailable: false
+      }));
 
       const toastErrorSpy = vi.spyOn(toast.default, 'error');
 
@@ -224,7 +226,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          loadSaveState: loadSaveStateSpy
+          loadSaveState: loadSaveStateSpy,
+          getCurrentGameName: () => 'some_rom.gba'
         } as GBAEmulator
       }));
 
@@ -252,7 +255,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          loadSaveState: loadSaveStateSpy
+          loadSaveState: loadSaveStateSpy,
+          getCurrentGameName: () => 'some_rom.gba'
         } as GBAEmulator
       }));
 
@@ -284,7 +288,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          createSaveState: createSaveStateSpy
+          createSaveState: createSaveStateSpy,
+          getCurrentGameName: () => 'some_rom.gba'
         } as GBAEmulator
       }));
 
@@ -322,7 +327,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          createSaveState: createSaveStateSpy
+          createSaveState: createSaveStateSpy,
+          getCurrentGameName: () => 'some_rom.gba'
         } as GBAEmulator
       }));
 

--- a/gbajs3/src/components/controls/virtual-controls.tsx
+++ b/gbajs3/src/components/controls/virtual-controls.tsx
@@ -65,7 +65,7 @@ export const VirtualControls = () => {
   const { getLayout } = useLayoutContext();
   const { initialBounds } = useInitialBoundsContext();
   const virtualControlToastId = useId();
-  const quickReload = useQuickReload();
+  const { quickReload } = useQuickReload();
   const { syncActionIfEnabled } = useAddCallbacks();
   const [currentSaveStateSlot] = useLocalStorage(
     saveStateSlotLocalStorageKey,

--- a/gbajs3/src/components/navigation-menu/navigation-menu.tsx
+++ b/gbajs3/src/components/navigation-menu/navigation-menu.tsx
@@ -180,7 +180,7 @@ export const NavigationMenu = () => {
   const isLargerThanPhone = useMediaQuery(theme.isLargerThanPhone);
   const isMobileLandscape = useMediaQuery(theme.isMobileLandscape);
   const menuHeaderId = useId();
-  const quickReload = useQuickReload();
+  const { quickReload, isQuickReloadAvailable } = useQuickReload();
 
   const isMenuItemDisabledByAuth = !isAuthenticated();
   const hasApiLocation = !!import.meta.env.VITE_GBA_SERVER_LOCATION;
@@ -321,12 +321,6 @@ export const NavigationMenu = () => {
               }}
             />
             <NavLeaf
-              title="Quick Reload"
-              $disabled={!isRunning}
-              icon={<BiRedo />}
-              onClick={quickReload}
-            />
-            <NavLeaf
               title="Manage Save States"
               $disabled={!isRunning}
               icon={<BiBookmarks />}
@@ -345,6 +339,14 @@ export const NavigationMenu = () => {
               }}
             />
           </NavComponent>
+
+          <NavLeaf
+            title="Quick Reload"
+            $disabled={!isQuickReloadAvailable}
+            icon={<BiRedo />}
+            $withPadding
+            onClick={quickReload}
+          />
 
           <NavLeaf
             title="Controls"

--- a/gbajs3/src/hooks/emulator/use-quick-reload.tsx
+++ b/gbajs3/src/hooks/emulator/use-quick-reload.tsx
@@ -13,16 +13,13 @@ export const useQuickReload = () => {
     emulatorGameNameLocalStorageKey
   );
 
+  const gameName = emulator?.getCurrentGameName() ?? storedGameName;
+  const isQuickReloadAvailable = isRunning || !!gameName;
+
   const quickReload = useCallback(() => {
-    const currentGameName = emulator?.getCurrentGameName();
+    if (isRunning) emulator?.quickReload();
+    else if (gameName) setIsRunning(runGame(gameName));
+  }, [emulator, isRunning, setIsRunning, runGame, gameName]);
 
-    if (isRunning) {
-      emulator?.quickReload();
-    } else {
-      const gameName = currentGameName ?? storedGameName;
-      if (gameName) setIsRunning(runGame(gameName));
-    }
-  }, [emulator, isRunning, setIsRunning, runGame, storedGameName]);
-
-  return quickReload;
+  return { quickReload, isQuickReloadAvailable };
 };

--- a/gbajs3/test/render-hook-with-context.tsx
+++ b/gbajs3/test/render-hook-with-context.tsx
@@ -1,12 +1,11 @@
-import {
-  renderHook
-} from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import { AllTheProviders } from './providers.tsx';
 
 import type {
   RenderHookOptions,
-  RenderHookResult} from '@testing-library/react';
+  RenderHookResult
+} from '@testing-library/react';
 
 export function renderHookWithContext<P, R>(
   callback: (props: P) => R,


### PR DESCRIPTION
- hoist quick reload to standalone menu item

- virtual controls are present by default on mobile, but not on desktop, this was covered by load local rom, but I thought it best to standardize this functionality