### PR TITLE
fix: service work ignore admin route

### DIFF
--- a/gbajs3/vite.config.ts
+++ b/gbajs3/vite.config.ts
@@ -101,7 +101,8 @@ export default defineConfig(({ mode }) => {
           ]
         },
         workbox: {
-          globPatterns: ['**/*.{js,css,html,wasm}']
+          globPatterns: ['**/*.{js,css,html,wasm}'],
+          navigateFallbackDenylist: [/^\/admin/]
         },
         ...(withCOIServiceWorker
           ? {


### PR DESCRIPTION
This change makes sure that accessing `/admin` in the browser works reliably. Previously, it wasn’t working because the service worker was intercepting the request.