### PR TITLE
fix: disable zoom

### DIFF
--- a/gbajs3/index.html
+++ b/gbajs3/index.html
@@ -22,5 +22,9 @@
     // Some libraries use the global object, even though it doesn't exist in the browser.
     // global got renamed to globalThis, causing a lot of problems
     const global = globalThis || window;
+
+    document.addEventListener('gesturestart', function (e) {
+      e.preventDefault();
+    });
   </script>
 </html>


### PR DESCRIPTION
Reproduction Steps:
1. On iOS, open the About modal from the menu
2. Pinch to zoom in using two fingers until it’s significantly enlarged
3. Close the modal
4. The emulator stays zoomed in and can't reset (shown in the screenshot)
5. The only way to recover is by reloading the page, which unfortunately causes progress loss

<img width="300" src="https://github.com/user-attachments/assets/36225831-dd39-4dee-9aca-8b52638275c2" alt="IMG_5857 (1280x)">


This PR addresses the issue by disabling zoom gestures on modals to prevent this behavior.
