### PR TITLE
fix: unintentional pinch zoom

### DIFF
--- a/gbajs3/src/components/modals/__snapshots__/modal-body.spec.tsx.snap
+++ b/gbajs3/src/components/modals/__snapshots__/modal-body.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`<ModalBody /> > container matches snapshot 1`] = `
 .c0 {
   padding: 1rem;
   overflow-y: auto;
+  touch-action: pan-x pan-y;
 }
 
 <div

--- a/gbajs3/src/components/shared/__snapshots__/error-boundary.spec.tsx.snap
+++ b/gbajs3/src/components/shared/__snapshots__/error-boundary.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`fallbackRender > renders styled fallback 1`] = `
 .c5 {
   padding: 1rem;
   overflow-y: auto;
+  touch-action: pan-x pan-y;
 }
 
 .c10 {

--- a/gbajs3/src/components/shared/styled.tsx
+++ b/gbajs3/src/components/shared/styled.tsx
@@ -24,6 +24,7 @@ export const HeaderWrapper = styled.div`
 export const BodyWrapper = styled.div`
   padding: 1rem;
   overflow-y: auto;
+  touch-action: pan-x pan-y;
 `;
 
 export const FooterWrapper = styled.div`


### PR DESCRIPTION
### High Level Details

- if the modal is zoomed, once based on other allowed touch actions you cannot un-zoom

- continued work related to https://github.com/thenick775/gbajs3/pull/124


### Related prs

https://github.com/thenick775/gbajs3/pull/319

Thanks @gutenye for pointing this one out, and for your contribution!