### PR TITLE
feat: display save state image

### DIFF
--- a/gbajs3/src/components/modals/save-states.spec.tsx
+++ b/gbajs3/src/components/modals/save-states.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -23,6 +23,9 @@ describe('<SaveStatesModal />', () => {
 
   it('renders with save states from current game and current slot', async () => {
     localStorage.setItem(saveStateSlotLocalStorageKey, '2');
+    const getSaveStateSpy: (saveStateName: string) => Uint8Array = vi.fn(
+      () => new Uint8Array()
+    );
 
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
@@ -32,8 +35,7 @@ describe('<SaveStatesModal />', () => {
       ...original(),
       emulator: {
         listCurrentSaveStates: () => ['rom0.ss0', 'rom0.ss1'],
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        getSaveState: (_) => new Uint8Array()
+        getSaveState: getSaveStateSpy
       } as GBAEmulator
     }));
 
@@ -46,9 +48,10 @@ describe('<SaveStatesModal />', () => {
     expect(
       screen.getByRole('button', { name: 'rom0.ss1' })
     ).toBeInTheDocument();
+    expect(getSaveStateSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('submits current slot', async () => {
+  it('updates current slot', async () => {
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
     renderWithContext(<SaveStatesModal />);
@@ -59,9 +62,14 @@ describe('<SaveStatesModal />', () => {
   });
 
   it('creates saves states', async () => {
-    const listCurrentSaveStatesSpy = vi.fn(() => ['rom0.ss0']);
+    const listCurrentSaveStatesSpy = vi
+      .fn()
+      .mockImplementationOnce(() => ['rom0.ss0'])
+      .mockImplementationOnce(() => ['rom0.ss0', 'rom0.ss1']);
     const createSaveStateSpy: (s: number) => boolean = vi.fn(() => true);
+    const getSaveStateSpy = vi.fn(() => new Uint8Array());
     const syncActionIfEnabledSpy = vi.fn();
+
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
     >('../../hooks/context.tsx');
@@ -73,9 +81,8 @@ describe('<SaveStatesModal />', () => {
       ...original(),
       emulator: {
         listCurrentSaveStates: listCurrentSaveStatesSpy as () => string[],
-        createSaveState: createSaveStateSpy,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        getSaveState: (_) => new Uint8Array()
+        getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array,
+        createSaveState: createSaveStateSpy
       } as GBAEmulator
     }));
 
@@ -86,7 +93,9 @@ describe('<SaveStatesModal />', () => {
 
     renderWithContext(<SaveStatesModal />);
 
-    listCurrentSaveStatesSpy.mockClear(); // clear calls from initial render
+    // clear calls from initial render
+    listCurrentSaveStatesSpy.mockClear();
+    getSaveStateSpy.mockClear();
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Create new save state' })
@@ -96,36 +105,47 @@ describe('<SaveStatesModal />', () => {
     expect(createSaveStateSpy).toHaveBeenCalledWith(1);
     expect(listCurrentSaveStatesSpy).toHaveBeenCalledOnce();
     expect(syncActionIfEnabledSpy).toHaveBeenCalledOnce();
+    expect(getSaveStateSpy).toHaveBeenCalledTimes(2);
   });
 
   it('renders error if creating save state fails', async () => {
+    const getSaveStateSpy = vi.fn(() => new Uint8Array());
+    const createSaveState: (slot: number) => boolean = () => false;
+    // must be stable
+    const emu = {
+      listCurrentSaveStates: () => ['rom0.ss0'],
+      getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array,
+      createSaveState: createSaveState
+    } as GBAEmulator;
+
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
     >('../../hooks/context.tsx');
 
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...original(),
-      emulator: {
-        listCurrentSaveStates: () => ['rom0.ss0'],
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        getSaveState: (_) => new Uint8Array(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        createSaveState: (_) => false
-      } as GBAEmulator
+      emulator: emu
     }));
 
     renderWithContext(<SaveStatesModal />);
+
+    getSaveStateSpy.mockClear();
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Create new save state' })
     );
 
     expect(screen.getByText('Failed to create save state')).toBeVisible();
+    expect(getSaveStateSpy).not.toHaveBeenCalled();
   });
 
   it('deletes saves states', async () => {
     const deleteSaveStateSpy: (s: number) => void = vi.fn();
-    const listCurrentSaveStatesSpy = vi.fn(() => ['rom0.ss0', 'rom0.ss1']);
+    const getSaveStateSpy = vi.fn(() => new Uint8Array());
+    const listCurrentSaveStatesSpy = vi
+      .fn()
+      .mockImplementationOnce(() => ['rom0.ss0', 'rom0.ss1'])
+      .mockImplementationOnce(() => ['rom0.ss0']);
     const syncActionIfEnabledSpy = vi.fn();
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
@@ -139,8 +159,9 @@ describe('<SaveStatesModal />', () => {
         ...original(),
         emulator: {
           listCurrentSaveStates: listCurrentSaveStatesSpy as () => string[],
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          getSaveState: (_) => new Uint8Array(),
+          getSaveState: getSaveStateSpy as (
+            saveStateName: string
+          ) => Uint8Array,
           deleteSaveState: deleteSaveStateSpy
         } as GBAEmulator
       };
@@ -153,7 +174,9 @@ describe('<SaveStatesModal />', () => {
 
     renderWithContext(<SaveStatesModal />);
 
-    listCurrentSaveStatesSpy.mockClear(); // clear calls from initial render
+    // clear calls from initial render
+    listCurrentSaveStatesSpy.mockClear();
+    getSaveStateSpy.mockClear();
 
     await userEvent.click(screen.getByLabelText('Delete rom0.ss1'));
 
@@ -161,33 +184,44 @@ describe('<SaveStatesModal />', () => {
     expect(deleteSaveStateSpy).toHaveBeenCalledWith(1);
     expect(listCurrentSaveStatesSpy).toHaveBeenCalledOnce();
     expect(syncActionIfEnabledSpy).toHaveBeenCalledOnce();
+    expect(getSaveStateSpy).toHaveBeenCalledTimes(1);
   });
 
   it('loads save state', async () => {
     const loadSaveStateSpy: (_: number) => boolean = vi.fn(() => true);
+    const getSaveStateSpy = vi.fn(() => new Uint8Array());
+    // must be stable
+    const emu = {
+      listCurrentSaveStates: () => ['some_rom.ss1'],
+      loadSaveState: loadSaveStateSpy,
+      getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array
+    } as GBAEmulator;
+
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
     >('../../hooks/context.tsx');
 
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...original(),
-      emulator: {
-        listCurrentSaveStates: () => ['some_rom.ss1'],
-        loadSaveState: loadSaveStateSpy,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        getSaveState: (_) => new Uint8Array()
-      } as GBAEmulator
+      emulator: emu
     }));
 
     renderWithContext(<SaveStatesModal />);
+
+    getSaveStateSpy.mockClear(); // clear calls from initial render
 
     await userEvent.click(screen.getByRole('button', { name: 'some_rom.ss1' }));
 
     expect(loadSaveStateSpy).toHaveBeenCalledOnce();
     expect(loadSaveStateSpy).toHaveBeenCalledWith(1);
+    expect(getSaveStateSpy).not.toHaveBeenCalled();
   });
 
   it('renders error if loading save state fails', async () => {
+    const getSaveState: (saveStateName: string) => Uint8Array = () =>
+      new Uint8Array();
+    const loadSaveState: (slot: number) => boolean = () => false;
+
     const { useEmulatorContext: original } = await vi.importActual<
       typeof contextHooks
     >('../../hooks/context.tsx');
@@ -196,10 +230,8 @@ describe('<SaveStatesModal />', () => {
       ...original(),
       emulator: {
         listCurrentSaveStates: () => ['rom0.ss0'],
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        getSaveState: (_) => new Uint8Array(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        loadSaveState: (_) => false
+        getSaveState: getSaveState,
+        loadSaveState: loadSaveState
       } as GBAEmulator
     }));
 
@@ -208,6 +240,50 @@ describe('<SaveStatesModal />', () => {
     await userEvent.click(screen.getByRole('button', { name: 'rom0.ss0' }));
 
     expect(screen.getByText('Failed to load save state')).toBeVisible();
+  });
+
+  it('opens and closes save state previews', async () => {
+    const getSaveState: (saveStateName: string) => Uint8Array = () =>
+      new Uint8Array([1, 2, 3]);
+
+    const { useEmulatorContext: original } = await vi.importActual<
+      typeof contextHooks
+    >('../../hooks/context.tsx');
+
+    vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
+      ...original(),
+      emulator: {
+        listCurrentSaveStates: () => ['rom0.ss0', 'rom0.ss1'],
+        getSaveState: getSaveState
+      } as GBAEmulator
+    }));
+
+    renderWithContext(<SaveStatesModal />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'View rom0.ss0' })
+    );
+
+    expect(screen.getByAltText('rom0.ss0 Preview')).toBeVisible();
+    expect(screen.getByAltText('rom0.ss1 Preview')).not.toBeVisible();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'View rom0.ss1' })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByAltText('rom0.ss0 Preview')).not.toBeVisible()
+    );
+    expect(screen.getByAltText('rom0.ss1 Preview')).toBeVisible();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Close rom0.ss1' })
+    );
+
+    expect(screen.getByAltText('rom0.ss0 Preview')).not.toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByAltText('rom0.ss1 Preview')).not.toBeVisible()
+    );
   });
 
   it('closes modal using the close button', async () => {

--- a/gbajs3/src/components/modals/save-states.tsx
+++ b/gbajs3/src/components/modals/save-states.tsx
@@ -209,7 +209,9 @@ export const SaveStatesModal = () => {
                   {saveState}
                 </LoadSaveStateButton>
                 <IconButton
-                  aria-label={`View ${saveState}`}
+                  aria-label={`${
+                    currentSaveStatePreview === saveState ? 'Close' : 'View'
+                  } ${saveState}`}
                   sx={{ padding: 0 }}
                   onClick={() =>
                     setCurrentSaveStatePreview(
@@ -239,7 +241,7 @@ export const SaveStatesModal = () => {
               <Collapse in={currentSaveStatePreview === saveState}>
                 <SaveStatePreview
                   src={saveStateImageUrls?.[idx]}
-                  alt={saveState}
+                  alt={`${saveState} Preview`}
                 />
               </Collapse>
             </StyledLi>

--- a/gbajs3/src/components/modals/save-states.tsx
+++ b/gbajs3/src/components/modals/save-states.tsx
@@ -1,8 +1,8 @@
-import { Button, IconButton } from '@mui/material';
+import { Button, Collapse, IconButton } from '@mui/material';
 import { useLocalStorage } from '@uidotdev/usehooks';
-import { useCallback, useEffect, useId, useState } from 'react';
-import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { BiError, BiTrash } from 'react-icons/bi';
+import { FaRegEye } from 'react-icons/fa';
 import { styled, useTheme } from 'styled-components';
 
 import { ModalBody } from './modal-body.tsx';
@@ -15,14 +15,9 @@ import {
   EmbeddedProductTour,
   type TourSteps
 } from '../product-tour/embedded-product-tour.tsx';
-import { CircleCheckButton } from '../shared/circle-check-button.tsx';
 import { ErrorWithIcon } from '../shared/error-with-icon.tsx';
 import { NumberInput } from '../shared/number-input.tsx';
 import { CenteredText, StyledBiPlus } from '../shared/styled.tsx';
-
-type InputProps = {
-  saveStateSlot: number;
-};
 
 const LoadSaveStateButton = styled.button`
   padding: 0.5rem 0.5rem;
@@ -39,14 +34,18 @@ const LoadSaveStateButton = styled.button`
 `;
 
 const StyledLi = styled.li`
-  cursor: pointer;
-  display: grid;
-  grid-template-columns: auto 32px;
-  gap: 10px;
-
+  display: flex;
+  flex-direction: column;
   color: ${({ theme }) => theme.blueCharcoal};
   background-color: ${({ theme }) => theme.pureWhite};
   border: 1px solid rgba(0, 0, 0, 0.125);
+`;
+
+const ButtonGrid = styled.div`
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: auto 32px 32px;
+  gap: 10px;
 `;
 
 const SaveStatesList = styled.ul`
@@ -76,13 +75,23 @@ const StyledBiTrash = styled(BiTrash)`
   width: 20px;
 `;
 
-const StyledForm = styled.form`
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
+const StyledFaRegEye = styled(FaRegEye)`
+  height: 100%;
+  width: 20px;
+`;
+
+const StateSlotContainer = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.pattensBlue};
   margin-bottom: 16px;
   padding-bottom: 16px;
+`;
+
+const SaveStatePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  image-rendering: pixelated;
 `;
 
 export const SaveStatesModal = () => {
@@ -91,7 +100,7 @@ export const SaveStatesModal = () => {
   const { emulator } = useEmulatorContext();
   const [currentSaveStates, setCurrentSaveStates] = useState<
     string[] | undefined
-  >();
+  >(emulator?.listCurrentSaveStates);
   const [saveStateError, setSaveStateError] = useState<string | null>(null);
   const [currentSlot, setCurrentSlot] = useLocalStorage(
     saveStateSlotLocalStorageKey,
@@ -99,46 +108,40 @@ export const SaveStatesModal = () => {
   );
   const { syncActionIfEnabled } = useAddCallbacks();
   const baseId = useId();
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    formState: { errors, isSubmitSuccessful }
-  } = useForm<InputProps>({
-    defaultValues: {
-      saveStateSlot: currentSlot
-    }
-  });
+  const [currentSaveStatePreview, setCurrentSaveStatePreview] = useState<
+    string | null
+  >(null);
 
   const refreshSaveStates = useCallback(() => {
-    const saveStatesList = emulator
-      ?.listSaveStates()
-      ?.filter((ss) => ss !== '.' && ss !== '..');
+    const saveStatesList = emulator?.listCurrentSaveStates();
 
     setCurrentSaveStates(saveStatesList);
   }, [emulator]);
 
-  useEffect(() => {
-    setValue('saveStateSlot', currentSlot);
-  }, [currentSlot, setValue]);
-
-  const onSubmit: SubmitHandler<InputProps> = async (formData) =>
-    setCurrentSlot(formData.saveStateSlot);
-
-  const renderedSaveStates =
-    currentSaveStates ??
-    emulator?.listSaveStates()?.filter((ss) => ss !== '.' && ss !== '..');
+  const saveStateImageUrls = useMemo(
+    () =>
+      currentSaveStates
+        ?.map((saveState) => {
+          const binary = emulator?.getSaveState(saveState);
+          if (binary?.length) {
+            const base64 = btoa(String.fromCharCode(...new Uint8Array(binary)));
+            return `data:image/png;base64,${base64}`;
+          }
+          return null;
+        })
+        .filter((url): url is string => url !== null),
+    [emulator, currentSaveStates]
+  );
 
   const tourSteps: TourSteps = [
     {
       content: (
         <p>
-          Use this input and button to manually update the current save state
-          slot in use.
+          Use this input to manually update the current save state slot in use.
         </p>
       ),
       placementBeacon: 'bottom-end',
-      target: `#${CSS.escape(`${baseId}--save-state-slot-form`)}`
+      target: `#${CSS.escape(`${baseId}--save-state-slot`)}`
     },
     {
       content: (
@@ -166,70 +169,82 @@ export const SaveStatesModal = () => {
     <>
       <ModalHeader title="Manage Save States" />
       <ModalBody>
-        <StyledForm
-          id={`${baseId}--save-state-slot-form`}
-          onSubmit={handleSubmit(onSubmit)}
-        >
+        <StateSlotContainer>
           <NumberInput
+            id={`${baseId}--save-state-slot`}
             label="Current Save State Slot"
             size="small"
-            error={!!errors?.saveStateSlot}
             min={0}
-            slotProps={{ inputLabel: { shrink: true } }}
-            {...register('saveStateSlot', {
-              required: { value: true, message: 'Slot is required' },
-              valueAsNumber: true
-            })}
+            value={currentSlot}
+            slotProps={{
+              inputLabel: { shrink: true },
+              input: {
+                onChange: (p) => setCurrentSlot(Number(p.target.value))
+              }
+            }}
+            sx={{ width: '100%' }}
           />
-          <CircleCheckButton
-            copy="Update Slot"
-            showSuccess={isSubmitSuccessful}
-            size="small"
-            type="submit"
-            sx={{ maxHeight: '40px', minWidth: 'fit-content' }}
-          />
-        </StyledForm>
+        </StateSlotContainer>
 
         <SaveStatesList id={`${baseId}--save-state-list`}>
-          {renderedSaveStates?.map?.((saveState: string, idx: number) => (
+          {currentSaveStates?.map?.((saveState: string, idx: number) => (
             <StyledLi key={`${saveState}_${idx}`}>
-              <LoadSaveStateButton
-                onClick={() => {
-                  const ext = saveState.split('.').pop();
-                  const slotString = ext?.replace('ss', '');
-                  if (slotString) {
-                    const slot = parseInt(slotString);
-                    const hasLoadedSaveState = emulator?.loadSaveState(slot);
-                    if (hasLoadedSaveState) {
-                      setCurrentSlot(slot);
-                      setSaveStateError(null);
-                    } else {
-                      setSaveStateError('Failed to load save state');
+              <ButtonGrid>
+                <LoadSaveStateButton
+                  onClick={() => {
+                    const ext = saveState.split('.').pop();
+                    const slotString = ext?.replace('ss', '');
+                    if (slotString) {
+                      const slot = parseInt(slotString);
+                      const hasLoadedSaveState = emulator?.loadSaveState(slot);
+                      if (hasLoadedSaveState) {
+                        setCurrentSlot(slot);
+                        setSaveStateError(null);
+                      } else {
+                        setSaveStateError('Failed to load save state');
+                      }
                     }
+                  }}
+                >
+                  {saveState}
+                </LoadSaveStateButton>
+                <IconButton
+                  aria-label={`View ${saveState}`}
+                  sx={{ padding: 0 }}
+                  onClick={() =>
+                    setCurrentSaveStatePreview(
+                      currentSaveStatePreview === saveState ? null : saveState
+                    )
                   }
-                }}
-              >
-                {saveState}
-              </LoadSaveStateButton>
-              <IconButton
-                aria-label={`Delete ${saveState}`}
-                sx={{ padding: 0 }}
-                onClick={() => {
-                  const ext = saveState.split('.').pop();
-                  const slotString = ext?.replace('ss', '');
-                  if (slotString) {
-                    const slot = parseInt(slotString);
-                    emulator?.deleteSaveState(slot);
-                    refreshSaveStates();
-                    syncActionIfEnabled();
-                  }
-                }}
-              >
-                <StyledBiTrash />
-              </IconButton>
+                >
+                  <StyledFaRegEye />
+                </IconButton>
+                <IconButton
+                  aria-label={`Delete ${saveState}`}
+                  sx={{ padding: 0 }}
+                  onClick={() => {
+                    const ext = saveState.split('.').pop();
+                    const slotString = ext?.replace('ss', '');
+                    if (slotString) {
+                      const slot = parseInt(slotString);
+                      emulator?.deleteSaveState(slot);
+                      refreshSaveStates();
+                      syncActionIfEnabled();
+                    }
+                  }}
+                >
+                  <StyledBiTrash />
+                </IconButton>
+              </ButtonGrid>
+              <Collapse in={currentSaveStatePreview === saveState}>
+                <SaveStatePreview
+                  src={saveStateImageUrls?.[idx]}
+                  alt={saveState}
+                />
+              </Collapse>
             </StyledLi>
           ))}
-          {!renderedSaveStates?.length && (
+          {!currentSaveStates?.length && (
             <li>
               <CenteredText>No save states</CenteredText>
             </li>

--- a/gbajs3/src/emulator/mgba/mgba-emulator.spec.tsx
+++ b/gbajs3/src/emulator/mgba/mgba-emulator.spec.tsx
@@ -221,9 +221,22 @@ cheat1_code = "XYZ789"`;
     expect(mockMGBA.bindKey).toHaveBeenCalledWith('Keypad 5', '5');
   });
 
-  it('should list all save states', () => {
-    const emulator = createEmulator();
-    expect(emulator.listSaveStates()).toEqual(['file1.sav', 'file2.sav']);
+  it('should list all current save states based on the game name', () => {
+    const emulator = createEmulator({
+      FS: {
+        ...mockMGBA.FS,
+        readdir: vi.fn(() => [
+          'testGame.ss1',
+          'testGame.ss2',
+          'file1.ss1',
+          'file2.ss2'
+        ])
+      } as unknown as typeof FS
+    });
+    expect(emulator.listCurrentSaveStates()).toEqual([
+      'testGame.ss1',
+      'testGame.ss2'
+    ]);
   });
 
   it('should delete a save state', () => {

--- a/gbajs3/src/hooks/emulator/use-quit-game.spec.tsx
+++ b/gbajs3/src/hooks/emulator/use-quit-game.spec.tsx
@@ -19,6 +19,7 @@ describe('useQuitGame hook', () => {
     const setIsRunningSpy = vi.fn();
     const fadeCanvasSpy = vi.fn();
     const testCanvas = {} as HTMLCanvasElement;
+    // must be stable
     const emu = {
       quitGame: emulatorQuitGameSpy,
       screenshot: screenshotSpy,


### PR DESCRIPTION
- allow for previewing save states as an image
- hide save states that do not refer to the current running ROM file
   - fixes issues with trying to delete a rom by save state slot index when it doesn't belong to the current running ROM