### PR TITLE
feat: refresh auto save state when displayed

### DIFF
--- a/gbajs3/src/components/controls/virtual-controls.spec.tsx
+++ b/gbajs3/src/components/controls/virtual-controls.spec.tsx
@@ -104,7 +104,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -132,7 +133,8 @@ describe('<VirtualControls />', () => {
       vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
         ...original(),
         emulator: {
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -227,7 +229,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           loadSaveState: loadSaveStateSpy,
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -256,7 +259,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           loadSaveState: loadSaveStateSpy,
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -283,7 +287,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           loadSaveState: loadSaveStateSpy,
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -316,7 +321,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           createSaveState: createSaveStateSpy,
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -355,7 +361,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           createSaveState: createSaveStateSpy,
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -388,7 +395,8 @@ describe('<VirtualControls />', () => {
         ...original(),
         emulator: {
           createSaveState: createSaveStateSpy,
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 

--- a/gbajs3/src/components/modals/cheats.spec.tsx
+++ b/gbajs3/src/components/modals/cheats.spec.tsx
@@ -61,7 +61,8 @@ describe('<CheatsModal />', () => {
           str && [
             { desc: 'cheat1', code: 'code1', enable: true },
             { desc: 'cheat2', code: 'code2', enable: false }
-          ]
+          ],
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -148,7 +149,8 @@ describe('<CheatsModal />', () => {
         autoLoadCheats: autoLoadCheatsSpy,
         getCurrentCheatsFile: () => testCheatsFile,
         parseCheatsString: (str) =>
-          str && [{ desc: 'cheat1', code: 'code1', enable: false }]
+          str && [{ desc: 'cheat1', code: 'code1', enable: false }],
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -203,7 +205,8 @@ describe('<CheatsModal />', () => {
         getCurrentCheatsFile: () => testCheatsFile,
         parseCheatsString: (str) =>
           str && [{ desc: 'cheat1', code: 'code1', enable: false }],
-        getCurrentCheatsFileName: getCurrentCheatsFileNameSpy
+        getCurrentCheatsFileName: getCurrentCheatsFileNameSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/emulator-settings.spec.tsx
+++ b/gbajs3/src/components/modals/emulator-settings.spec.tsx
@@ -26,7 +26,8 @@ describe('<EmulatorSettingsModal />', () => {
       ...originalEmulator(),
       emulator: {
         defaultAudioSampleRates: () => defaultSampleRates,
-        defaultAudioBufferSizes: () => defaultAudioBufferSizes
+        defaultAudioBufferSizes: () => defaultAudioBufferSizes,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
   });
@@ -76,7 +77,8 @@ describe('<EmulatorSettingsModal />', () => {
       emulator: {
         setCoreSettings: setCoreSettingsSpy,
         defaultAudioSampleRates: () => defaultSampleRates,
-        defaultAudioBufferSizes: () => defaultAudioBufferSizes
+        defaultAudioBufferSizes: () => defaultAudioBufferSizes,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -143,7 +145,8 @@ describe('<EmulatorSettingsModal />', () => {
         setCoreSettings: setCoreSettingsSpy,
         getCurrentSaveName: () => 'current_save.sav',
         defaultAudioSampleRates: () => defaultSampleRates,
-        defaultAudioBufferSizes: () => defaultAudioBufferSizes
+        defaultAudioBufferSizes: () => defaultAudioBufferSizes,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -291,7 +294,8 @@ describe('<EmulatorSettingsModal />', () => {
         setCoreSettings: setCoreSettingsSpy,
         getCurrentSaveName: () => 'current_save.sav',
         defaultAudioSampleRates: () => defaultSampleRates,
-        defaultAudioBufferSizes: () => defaultAudioBufferSizes
+        defaultAudioBufferSizes: () => defaultAudioBufferSizes,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -350,7 +354,8 @@ describe('<EmulatorSettingsModal />', () => {
       emulator: {
         getCurrentSaveName: () => 'current_save.sav',
         defaultAudioSampleRates: () => defaultSampleRates,
-        defaultAudioBufferSizes: () => defaultAudioBufferSizes
+        defaultAudioBufferSizes: () => defaultAudioBufferSizes,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/file-system.spec.tsx
+++ b/gbajs3/src/components/modals/file-system.spec.tsx
@@ -41,7 +41,8 @@ describe('<FileSystemModal />', () => {
       return {
         ...original(),
         emulator: {
-          listAllFiles: () => defaultFSData
+          listAllFiles: () => defaultFSData,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       };
     });
@@ -73,7 +74,8 @@ describe('<FileSystemModal />', () => {
         ...original(),
         emulator: {
           listAllFiles: listAllFilesSpy as () => FileNode,
-          deleteFile: deleteFileSpy
+          deleteFile: deleteFileSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       };
     });
@@ -118,7 +120,8 @@ describe('<FileSystemModal />', () => {
         ...original(),
         emulator: {
           listAllFiles: () => defaultFSData,
-          getFile: getFileSpy
+          getFile: getFileSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       };
     });
@@ -149,7 +152,8 @@ describe('<FileSystemModal />', () => {
       ...original(),
       emulator: {
         listAllFiles: () => defaultFSData,
-        fsSync: emulatorFSSyncSpy
+        fsSync: emulatorFSSyncSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -197,7 +201,8 @@ describe('<FileSystemModal />', () => {
       return {
         ...originalEmulator(),
         emulator: {
-          listAllFiles: () => defaultFSData
+          listAllFiles: () => defaultFSData,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       };
     });

--- a/gbajs3/src/components/modals/file-system.tsx
+++ b/gbajs3/src/components/modals/file-system.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mui/material';
-import { useCallback, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { styled } from 'styled-components';
 
 import { EmulatorFileSystem } from './file-system/emulator-file-system.tsx';
@@ -8,6 +8,7 @@ import { ModalFooter } from './modal-footer.tsx';
 import { ModalHeader } from './modal-header.tsx';
 import { useEmulatorContext, useModalContext } from '../../hooks/context.tsx';
 import { useAddCallbacks } from '../../hooks/emulator/use-add-callbacks.tsx';
+import { useFileStat } from '../../hooks/emulator/use-file-stat.tsx';
 import {
   EmbeddedProductTour,
   type TourSteps
@@ -36,6 +37,17 @@ export const FileSystemModal = () => {
       syncActionIfEnabled();
     },
     [emulator, syncActionIfEnabled]
+  );
+
+  // the only flow that can force the file system to change without user interaction after the modal
+  // is open is the auto save state timer, if the modified time of the current auto save state has
+  // changed, we should refresh the file system view
+  const autoSaveStatePath = emulator?.getCurrentAutoSaveStatePath();
+  const { modifiedTime } = useFileStat(autoSaveStatePath);
+
+  useEffect(
+    () => setAllFiles(emulator?.listAllFiles()),
+    [emulator, modifiedTime]
   );
 
   const downloadFile = (path: string) => {

--- a/gbajs3/src/components/modals/file-system.tsx
+++ b/gbajs3/src/components/modals/file-system.tsx
@@ -39,12 +39,12 @@ export const FileSystemModal = () => {
     [emulator, syncActionIfEnabled]
   );
 
-  // the only flow that can force the file system to change without user interaction after the modal
-  // is open is the auto save state timer, if the modified time of the current auto save state has
-  // changed, we should refresh the file system view
   const autoSaveStatePath = emulator?.getCurrentAutoSaveStatePath();
   const { modifiedTime } = useFileStat(autoSaveStatePath);
 
+  // the only flow that can force the file system to change without user interaction after the modal
+  // is open is the auto save state timer, if the modified time of the current auto save state has
+  // changed, we should refresh the file system view
   useEffect(
     () => setAllFiles(emulator?.listAllFiles()),
     [emulator, modifiedTime]

--- a/gbajs3/src/components/modals/load-local-rom.spec.tsx
+++ b/gbajs3/src/components/modals/load-local-rom.spec.tsx
@@ -29,7 +29,8 @@ describe('<LoadLocalRomModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...original(),
       emulator: {
-        listRoms: () => ['rom1.gba', 'rom2.gba']
+        listRoms: () => ['rom1.gba', 'rom2.gba'],
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -58,7 +59,8 @@ describe('<LoadLocalRomModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        listRoms: () => ['rom1.gba']
+        listRoms: () => ['rom1.gba'],
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/load-rom.spec.tsx
+++ b/gbajs3/src/components/modals/load-rom.spec.tsx
@@ -37,7 +37,8 @@ describe('<LoadRomModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/load-save.spec.tsx
+++ b/gbajs3/src/components/modals/load-save.spec.tsx
@@ -34,7 +34,8 @@ describe('<LoadSaveModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadSaveOrSaveState: uploadSaveOrSaveStateSpy
+        uploadSaveOrSaveState: uploadSaveOrSaveStateSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/save-states.spec.tsx
+++ b/gbajs3/src/components/modals/save-states.spec.tsx
@@ -36,7 +36,8 @@ describe('<SaveStatesModal />', () => {
         listCurrentSaveStates: () => ['rom0.ss0', 'rom0.ss1'],
         getCurrentGameName: () => 'rom0.gba',
         getSaveState: getSaveStateSpy,
-        getAutoSaveState: () => null
+        getAutoSaveState: () => null,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -72,7 +73,8 @@ describe('<SaveStatesModal />', () => {
         getAutoSaveState: () => ({
           autoSaveStateName: 'rom0_auto.ss',
           data: new Uint8Array([1, 2, 3])
-        })
+        }),
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -97,7 +99,8 @@ describe('<SaveStatesModal />', () => {
       ...original(),
       emulator: {
         getCurrentGameName: () => 'some_rom.gba',
-        getAutoSaveState: () => null
+        getAutoSaveState: () => null,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -134,7 +137,8 @@ describe('<SaveStatesModal />', () => {
         listCurrentSaveStates: listCurrentSaveStatesSpy as () => string[],
         getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array,
         createSaveState: createSaveStateSpy,
-        getAutoSaveState: () => null
+        getAutoSaveState: () => null,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -169,7 +173,8 @@ describe('<SaveStatesModal />', () => {
       getCurrentGameName: () => 'rom0.gba',
       getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array,
       createSaveState: createSaveState,
-      getAutoSaveState: () => null
+      getAutoSaveState: () => null,
+      getCurrentAutoSaveStatePath: () => null
     } as GBAEmulator;
 
     const { useEmulatorContext: original } = await vi.importActual<
@@ -218,7 +223,8 @@ describe('<SaveStatesModal />', () => {
             saveStateName: string
           ) => Uint8Array,
           deleteSaveState: deleteSaveStateSpy,
-          getAutoSaveState: () => null
+          getAutoSaveState: () => null,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       };
     });
@@ -259,7 +265,8 @@ describe('<SaveStatesModal />', () => {
           autoSaveStateName: 'rom0_auto.ss',
           data: new Uint8Array([1, 2, 3])
         }),
-        deleteFile: deleteFileSpy
+        deleteFile: deleteFileSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -280,7 +287,8 @@ describe('<SaveStatesModal />', () => {
       getCurrentGameName: () => 'some_rom.gba',
       loadSaveState: loadSaveStateSpy,
       getSaveState: getSaveStateSpy as (saveStateName: string) => Uint8Array,
-      getAutoSaveState: () => null
+      getAutoSaveState: () => null,
+      getCurrentAutoSaveStatePath: () => null
     } as GBAEmulator;
 
     const { useEmulatorContext: original } = await vi.importActual<
@@ -319,7 +327,8 @@ describe('<SaveStatesModal />', () => {
         getCurrentGameName: () => 'rom0.gba',
         getSaveState: getSaveState,
         loadSaveState: loadSaveState,
-        getAutoSaveState: () => null
+        getAutoSaveState: () => null,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -344,7 +353,8 @@ describe('<SaveStatesModal />', () => {
         listCurrentSaveStates: () => ['rom0.ss0', 'rom0.ss1'],
         getCurrentGameName: () => 'rom0.gba',
         getSaveState: getSaveState,
-        getAutoSaveState: () => null
+        getAutoSaveState: () => null,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -389,7 +399,8 @@ describe('<SaveStatesModal />', () => {
         getAutoSaveState: () => ({
           autoSaveStateName: 'rom0_auto.ss',
           data: new Uint8Array([1, 2, 3])
-        })
+        }),
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/save-states.tsx
+++ b/gbajs3/src/components/modals/save-states.tsx
@@ -10,6 +10,7 @@ import { ModalFooter } from './modal-footer.tsx';
 import { ModalHeader } from './modal-header.tsx';
 import { useEmulatorContext, useModalContext } from '../../hooks/context.tsx';
 import { useAddCallbacks } from '../../hooks/emulator/use-add-callbacks.tsx';
+import { useFileStat } from '../../hooks/emulator/use-file-stat.tsx';
 import { saveStateSlotsLocalStorageKey } from '../controls/consts.tsx';
 import {
   EmbeddedProductTour,
@@ -215,6 +216,9 @@ export const SaveStatesModal = () => {
     .pop();
   const autoSaveStateImage = uint8ArrayToBase64DataUrl(autoSaveStateData?.data);
 
+  const autoSaveStatePath = emulator?.getCurrentAutoSaveStatePath();
+  const { trigger } = useFileStat(autoSaveStatePath);
+
   const toggleCurrentSaveStatePreview = (saveStateName: string) =>
     setCurrentSaveStatePreview(
       currentSaveStatePreview === saveStateName ? null : saveStateName
@@ -287,8 +291,10 @@ export const SaveStatesModal = () => {
               }
               onClick={emulator?.loadAutoSaveState}
               onDelete={() => {
-                if (autoSaveStateData?.autoSaveStateName)
+                if (autoSaveStateData?.autoSaveStateName) {
                   emulator?.deleteFile(autoSaveStateData.autoSaveStateName);
+                  trigger();
+                }
               }}
             />
           )}

--- a/gbajs3/src/components/modals/upload-cheats.spec.tsx
+++ b/gbajs3/src/components/modals/upload-cheats.spec.tsx
@@ -29,7 +29,8 @@ describe('<UploadCheatsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadCheats: uploadCheatsSpy
+        uploadCheats: uploadCheatsSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -85,7 +86,8 @@ describe('<UploadCheatsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadCheats: uploadCheatsSpy
+        uploadCheats: uploadCheatsSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/upload-patches.spec.tsx
+++ b/gbajs3/src/components/modals/upload-patches.spec.tsx
@@ -29,7 +29,8 @@ describe('<UploadPatchesModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadPatch: uploadPatchSpy
+        uploadPatch: uploadPatchSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -85,7 +86,8 @@ describe('<UploadPatchesModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadPatch: uploadPatchSpy
+        uploadPatch: uploadPatchSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/upload-public-external-roms.spec.tsx
+++ b/gbajs3/src/components/modals/upload-public-external-roms.spec.tsx
@@ -38,7 +38,8 @@ describe('<UploadPublicExternalRomsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -97,7 +98,8 @@ describe('<UploadPublicExternalRomsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/upload-roms.spec.tsx
+++ b/gbajs3/src/components/modals/upload-roms.spec.tsx
@@ -38,7 +38,8 @@ describe('<UploadRomsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -93,7 +94,8 @@ describe('<UploadRomsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -165,7 +167,8 @@ describe('<UploadRomsModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadRom: uploadRomSpy
+        uploadRom: uploadRomSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -240,7 +243,8 @@ describe('<UploadRomsModal />', () => {
 
     // needs to be a consistent object
     const testEmu = {
-      uploadRom: uploadRomSpy
+      uploadRom: uploadRomSpy,
+      getCurrentAutoSaveStatePath: () => null
     } as GBAEmulator;
 
     vi.spyOn(contextHooks, 'useModalContext').mockImplementation(() => ({
@@ -301,7 +305,8 @@ describe('<UploadRomsModal />', () => {
       ...originalEmulator(),
       emulator: {
         uploadRom: uploadRomSpy,
-        run: emulatorRunSpy
+        run: emulatorRunSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/modals/upload-saves.spec.tsx
+++ b/gbajs3/src/components/modals/upload-saves.spec.tsx
@@ -28,7 +28,8 @@ describe('<UploadSavesModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadSaveOrSaveState: uploadSaveOrSaveStateSpy
+        uploadSaveOrSaveState: uploadSaveOrSaveStateSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 
@@ -84,7 +85,8 @@ describe('<UploadSavesModal />', () => {
     vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
       ...originalEmulator(),
       emulator: {
-        uploadSaveOrSaveState: uploadSaveSpy
+        uploadSaveOrSaveState: uploadSaveSpy,
+        getCurrentAutoSaveStatePath: () => null
       } as GBAEmulator
     }));
 

--- a/gbajs3/src/components/navigation-menu/navigation-menu.spec.tsx
+++ b/gbajs3/src/components/navigation-menu/navigation-menu.spec.tsx
@@ -223,7 +223,8 @@ describe('<NavigationMenu />', () => {
         ...originalEmulator(),
         emulator: {
           screenshot: screenshotSpy,
-          getCurrentGameName: () => '/some_rom.gba'
+          getCurrentGameName: () => '/some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator,
         canvas: {} as HTMLCanvasElement
       }));
@@ -259,7 +260,8 @@ describe('<NavigationMenu />', () => {
         ...originalEmulator(),
         emulator: {
           screenshot: () => false,
-          getCurrentGameName: () => '/some_rom.gba'
+          getCurrentGameName: () => '/some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator,
         canvas: {} as HTMLCanvasElement
       }));

--- a/gbajs3/src/emulator/mgba/mgba-emulator.tsx
+++ b/gbajs3/src/emulator/mgba/mgba-emulator.tsx
@@ -45,6 +45,8 @@ export type GBAEmulator = {
   getCurrentSave: () => Uint8Array | null;
   getCurrentSaveName: () => string | undefined;
   getFile: (path: string) => Uint8Array;
+  getStat: (path: string) => FS.Stats;
+  getCurrentAutoSaveStatePath: () => string | null;
   getVolume: () => number;
   isFastForwardEnabled: () => boolean;
   listAllFiles: () => FileNode;
@@ -286,7 +288,10 @@ export const mGBAEmulator = (mGBA: mGBAEmulatorTypeDef): GBAEmulator => {
     getCurrentGameName: () => filepathToFileName(mGBA.gameName),
     getCurrentSave: () => (mGBA.saveName ? mGBA.getSave() : null),
     getCurrentSaveName: () => filepathToFileName(mGBA.saveName),
+    getCurrentAutoSaveStatePath: () =>
+      mGBA.autoSaveStateName ? mGBA.autoSaveStateName : null,
     getFile: (path) => mGBA.FS.readFile(path),
+    getStat: (path) => mGBA.FS.stat(path),
     uploadCheats: mGBA.uploadCheats,
     uploadPatch: mGBA.uploadPatch,
     uploadRom: mGBA.uploadRom,

--- a/gbajs3/src/hooks/emulator/use-add-callbacks.spec.tsx
+++ b/gbajs3/src/hooks/emulator/use-add-callbacks.spec.tsx
@@ -103,7 +103,8 @@ describe('useAddCallbacks hook', () => {
           setCanvas: vi.fn(),
           canvas: null,
           emulator: {
-            addCoreCallbacks: emulatorAddCoreCallbacksSpy
+            addCoreCallbacks: emulatorAddCoreCallbacksSpy,
+            getCurrentAutoSaveStatePath: () => null
           } as GBAEmulator
         }));
 
@@ -125,7 +126,8 @@ describe('useAddCallbacks hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          fsSync: emulatorFSSyncSpy
+          fsSync: emulatorFSSyncSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -152,7 +154,8 @@ describe('useAddCallbacks hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          fsSync: emulatorFSSyncSpy
+          fsSync: emulatorFSSyncSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -178,7 +181,8 @@ describe('useAddCallbacks hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          fsSync: emulatorFSSyncSpy
+          fsSync: emulatorFSSyncSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 

--- a/gbajs3/src/hooks/emulator/use-add-callbacks.tsx
+++ b/gbajs3/src/hooks/emulator/use-add-callbacks.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 
 import { emulatorSettingsLocalStorageKey } from '../../context/emulator/consts.ts';
 import { useEmulatorContext } from '../context.tsx';
+import { useFileStat } from './use-file-stat.tsx';
 
 import type { EmulatorSettings } from '../../components/modals/emulator-settings.tsx';
 
@@ -28,6 +29,8 @@ export const useAddCallbacks = () => {
   const [emulatorSettings] = useLocalStorage<EmulatorSettings | undefined>(
     emulatorSettingsLocalStorageKey
   );
+  const autoSaveStatePath = emulator?.getCurrentAutoSaveStatePath();
+  const { trigger } = useFileStat(autoSaveStatePath);
 
   const syncActionIfEnabled = useCallback(
     async ({ withToast = true }: SyncActionIfEnabledProps = {}) => {
@@ -61,10 +64,13 @@ export const useAddCallbacks = () => {
         ),
         autoSaveStateCapturedCallback: optionalFunc(
           options.autoSaveStateCaptureNotificationEnabled,
-          () => toast.success('Auto save state captured')
+          () => {
+            toast.success('Auto save state captured');
+            trigger();
+          }
         )
       }),
-    [emulator]
+    [emulator, trigger]
   );
 
   return {

--- a/gbajs3/src/hooks/emulator/use-file-stat.tsx
+++ b/gbajs3/src/hooks/emulator/use-file-stat.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { useEmulatorContext } from '../context.tsx';
+
+const listeners = new Set<() => void>();
+
+const subscribe = (callback: () => void) => {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+};
+
+const trigger = () => listeners.forEach((cb) => cb());
+
+export const useFileStat = (path?: string | null) => {
+  const { emulator } = useEmulatorContext();
+  const getSnapshot = useCallback(() => {
+    if (!path) return undefined;
+
+    try {
+      return emulator?.getStat(path).mtime.getTime();
+    } catch {
+      return null;
+    }
+  }, [path, emulator]);
+
+  const modifiedTime = useSyncExternalStore(subscribe, getSnapshot);
+
+  return { modifiedTime, trigger };
+};

--- a/gbajs3/src/hooks/emulator/use-quick-reload.spec.tsx
+++ b/gbajs3/src/hooks/emulator/use-quick-reload.spec.tsx
@@ -20,7 +20,8 @@ describe('useQuickReload hook', () => {
         canvas: null,
         emulator: {
           getCurrentGameName: () => undefined,
-          quickReload: emulatorQuickReloadSpy
+          quickReload: emulatorQuickReloadSpy,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -52,7 +53,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -92,7 +94,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -128,7 +131,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -151,7 +155,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => 'some_rom.gba'
+          getCurrentGameName: () => 'some_rom.gba',
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -176,7 +181,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 
@@ -194,7 +200,8 @@ describe('useQuickReload hook', () => {
         setCanvas: vi.fn(),
         canvas: null,
         emulator: {
-          getCurrentGameName: () => undefined
+          getCurrentGameName: () => undefined,
+          getCurrentAutoSaveStatePath: () => null
         } as GBAEmulator
       }));
 


### PR DESCRIPTION
### High Level Details

- auto refreshes auto save state information based on modified timestamp
   - adjusts tests accordingly
- specifically for views like the save states view/file system
   - the assumption before is that no actual file system changes could take place while these modals were open, because the user would have to initiate them
   - we now diverge from that behavior slightly, given we have periodic auto save state capabilities
   - this pr is to tighten this back up
- Note: last pr blocker before minor release