### PR TITLE
fix: save state image large call stack explosion

### DIFF
--- a/gbajs3/src/components/modals/save-states.tsx
+++ b/gbajs3/src/components/modals/save-states.tsx
@@ -105,13 +105,12 @@ const SaveStatePreview = styled.img`
   image-rendering: pixelated;
 `;
 
-const uint8ArrayToBase64DataUrl = (binary?: Uint8Array) => {
-  if (binary?.length) {
-    const base64 = btoa(String.fromCharCode(...new Uint8Array(binary)));
-    return `data:image/png;base64,${base64}`;
-  }
-  return undefined;
-};
+const uint8ArrayToBase64DataUrl = (binary?: Uint8Array) =>
+  binary?.length
+    ? `data:image/png;base64,${btoa(
+        Array.from(binary, (b) => String.fromCharCode(b)).join('')
+      )}`
+    : undefined;
 
 const parseSaveStateSlot = (saveStateName: string) => {
   const ext = saveStateName.split('.').pop();


### PR DESCRIPTION
### High Level Details

- fixes the following error in the save states modal

```
RangeError: Maximum call stack size exceeded
at $h (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:764:66)
at px (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:764:1165)
at Bc (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:34138)
at Ic (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:62119)
at ed (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:72623)
at wd (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:106660)
at o0 (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:105725)
at To (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:105557)
at jd (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:102667)
at Vd (https://gba.nicholas-vancise.dev/assets/index-Bbw5LH-s.js:24:114212)
```

### Issue

See #378

### Rationale

The `RangeError: Maximum call stack size exceeded` was caused by the previous implementation of the save state preview conversion logic, which used:

```ts
String.fromCharCode(...new Uint8Array(binary))
```

My last approach spread the entire binary buffer as individual arguments to `String.fromCharCode`.

When dealing with large Uint8Array buffers, this call can exceed the JavaScript engine’s internal argument stack limit, resulting in a RangeError, where this limit can vary across browsers to an extent where I dont see it but others can!

This solution:
- Removes all spread operations (...binary) that could overflow the call stack.
- Uses Array.from and .join(''), which are defined in the ECMAScript specification as iterative, not recursive — ensuring constant stack depth regardless of input size.
