### PR TITLE
feat: enable sourcemaps

### DIFF
--- a/gbajs3/vite.config.ts
+++ b/gbajs3/vite.config.ts
@@ -128,6 +128,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     build: {
+      sourcemap: true,
       rollupOptions: {
         output: {
           manualChunks: {


### PR DESCRIPTION
- enables clearer errors when the user hits the error boundary
- nothing in this repo is private, so this is a-OK

i.e.

after:

```
react-dom-client.production.js:5892 ReferenceError: Cannot access 'S' before initialization
    at Object.refetchInterval (auth-provider.tsx:51:9)
    at #y (queryObserver.js:206:79)
    at eb.setOptions (queryObserver.js:115:38)
    at new eb (queryObserver.js:26:10)
    at useBaseQuery.js:48:11
    at oo (react-dom-client.production.js:4769:20)
    at Object.useState (react-dom-client.production.js:5565:22)
    at n.useState (react.production.js:526:33)
    at Sb (useBaseQuery.js:47:22)
    at Ic (useQuery.js:7:10)
```

before:

```
index-Cf9TKhx3.js:8 ReferenceError: Cannot access 'S' before initializ
    ation 
    at Object.refetchInterval (index-Cf9TKhx3.js:935:2019) 
    at #y (index-Cf9TKhx3.js:9:53205) 
    at eb.setOptions (index-Cf9TKhx3.js:9:51869) 
    at new eb (index-Cf9TKhx3.js:9:50514) 
    at index-Cf9TKhx3.js:9:71232 
    at oo (index-Cf9TKhx3.js:8:52858) 
    at Object.useSt
    ate (index-Cf9TKhx3.js:8:61011) 
    at n.useSt
    ate (react-CCYiWZgt.js:1:7972) 
    at Sb (index-Cf9TKhx3.js:9:71219) 
    at Ic (index-Cf9TKhx3.js:9:71957)
```