### PR TITLE
fix: virtual controls positions resetting incorrectly on orientation change

### DIFF
--- a/gbajs3/src/context/initial-bounds/initial-bounds-provider.tsx
+++ b/gbajs3/src/context/initial-bounds/initial-bounds-provider.tsx
@@ -47,6 +47,10 @@ export const InitialBoundsProvider = ({
 
   useEffect(() => {
     if (
+      prevSize.current.width !== null &&
+      prevSize.current.height !== null &&
+      windowSize.width !== null &&
+      windowSize.height !== null &&
       windowSize.width !== prevSize.current.width &&
       windowSize.height !== prevSize.current.height &&
       hasInitialBounds


### PR DESCRIPTION
### High Level Details

- fix an issue with double clearing of screen initial bounds after screen layout is set
- symptoms
   - virtual controls dont show on first render

### Screenshots

After:

https://github.com/user-attachments/assets/2ede0f52-d453-4676-bcfe-6be583cbfe8e

Before:

https://github.com/user-attachments/assets/edf8d4ac-a230-4678-a6aa-a82d73d4ef4a
