### PR TITLE
feat: truncate save 128KiB option

### DIFF
--- a/gbajs3/src/components/modals/download-save.spec.tsx
+++ b/gbajs3/src/components/modals/download-save.spec.tsx
@@ -18,6 +18,11 @@ describe('<DownloadSaveModal />', () => {
         'Remember to save in game before downloading your save file!'
       )
     ).toBeVisible();
+    expect(
+      screen.getByRole('checkbox', {
+        name: /Truncate save \(128 KiB\)/i
+      })
+    ).not.toBeChecked();
   });
 
   it('renders error if there is no current save or save name', async () => {
@@ -72,6 +77,38 @@ describe('<DownloadSaveModal />', () => {
       'some_rom.sav',
       expect.any(Blob)
     );
+  });
+
+  it('downloads a truncated save when requested', async () => {
+    const { useEmulatorContext: original } = await vi.importActual<
+      typeof contextHooks
+    >('../../hooks/context.tsx');
+    const downloadBlobSpy = vi
+      .spyOn(blobUtilities, 'downloadBlob')
+      .mockImplementation(() => new Blob());
+    const getCurrentSaveTruncated = vi.fn(() =>
+      new TextEncoder().encode('Some truncated sav file contents')
+    );
+    const getCurrentSave = vi.fn(() => new TextEncoder().encode('raw save'));
+
+    vi.spyOn(contextHooks, 'useEmulatorContext').mockImplementation(() => ({
+      ...original(),
+      emulator: {
+        ...original().emulator,
+        getCurrentSave,
+        getCurrentSaveTruncated: getCurrentSaveTruncated,
+        getCurrentSaveName: () => 'some_rom.sav'
+      } as GBAEmulator
+    }));
+
+    renderWithContext(<DownloadSaveModal />);
+
+    await userEvent.click(screen.getByText('Truncate save (128 KiB)'));
+    await userEvent.click(screen.getByText('Download', { selector: 'button' }));
+
+    expect(getCurrentSaveTruncated).toHaveBeenCalledWith(131072);
+    expect(getCurrentSave).not.toHaveBeenCalled();
+    expect(downloadBlobSpy).toHaveBeenCalledOnce();
   });
 
   it('closes modal using the close button', async () => {

--- a/gbajs3/src/components/modals/download-save.tsx
+++ b/gbajs3/src/components/modals/download-save.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mui/material';
+import { Box, Button, Divider, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useId, useState } from 'react';
 import { BiError } from 'react-icons/bi';
@@ -8,8 +8,11 @@ import { ModalFooter } from './modal-footer.tsx';
 import { ModalHeader } from './modal-header.tsx';
 import { useEmulatorContext, useModalContext } from '../../hooks/context.tsx';
 import { ErrorWithIcon } from '../shared/error-with-icon.tsx';
-import { CenteredText } from '../shared/styled.tsx';
+import { ManagedCheckbox } from '../shared/managed-checkbox.tsx';
+import { Copy } from '../shared/styled.tsx';
 import { downloadBlob } from './file-utilities/blob.ts';
+
+const saveSize128KiBBytes = 128 * 1024;
 
 export const DownloadSaveModal = () => {
   const theme = useTheme();
@@ -17,6 +20,7 @@ export const DownloadSaveModal = () => {
   const { emulator } = useEmulatorContext();
   const downloadSaveButtonId = useId();
   const [error, setError] = useState(false);
+  const [downloadTruncatedSave, setDownloadTruncatedSave] = useState(false);
 
   return (
     <>
@@ -28,17 +32,37 @@ export const DownloadSaveModal = () => {
             text="Load a rom to download its save file"
           />
         ) : (
-          <CenteredText>
+          <Copy>
             Remember to save in game before downloading your save file!
-          </CenteredText>
+          </Copy>
         )}
+        <Divider flexItem sx={{ margin: '10px 0' }} />
+        <Copy>Download Options</Copy>
+        <ManagedCheckbox
+          label={
+            <Box sx={{ ml: 1, my: 1 }}>
+              <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                Truncate save (128 KiB)
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Removes metadata at the end of the sav file
+              </Typography>
+            </Box>
+          }
+          watcher={downloadTruncatedSave}
+          onChange={(_, checked) => {
+            setDownloadTruncatedSave(checked);
+          }}
+        />
       </ModalBody>
       <ModalFooter>
         <Button
           id={downloadSaveButtonId}
           variant="contained"
           onClick={() => {
-            const save = emulator?.getCurrentSave();
+            const save = downloadTruncatedSave
+              ? emulator?.getCurrentSaveTruncated(saveSize128KiBBytes)
+              : emulator?.getCurrentSave();
             const saveName = emulator?.getCurrentSaveName();
 
             if (save && saveName) {

--- a/gbajs3/src/components/shared/managed-checkbox.tsx
+++ b/gbajs3/src/components/shared/managed-checkbox.tsx
@@ -1,7 +1,9 @@
 import { Checkbox, FormControlLabel, type CheckboxProps } from '@mui/material';
 
+import type { ReactNode } from 'react';
+
 type ManagedCheckBoxProps = {
-  label: string;
+  label: ReactNode;
   watcher?: boolean;
 } & CheckboxProps;
 

--- a/gbajs3/src/emulator/mgba/mgba-emulator.spec.tsx
+++ b/gbajs3/src/emulator/mgba/mgba-emulator.spec.tsx
@@ -404,6 +404,19 @@ cheat1_code = "XYZ789"`;
     expect(emulator.getCurrentSave()).toBeNull();
   });
 
+  it('should return a truncated current save file when requested', () => {
+    const save = new Uint8Array([1, 2, 3, 4]);
+    const { emulator } = createEmulator({ getSave: vi.fn(() => save) });
+
+    expect(emulator.getCurrentSaveTruncated(2)).toEqual(new Uint8Array([1, 2]));
+  });
+
+  it('should return null for a truncated save when no save is loaded', () => {
+    const { emulator } = createEmulator({ saveName: undefined });
+
+    expect(emulator.getCurrentSaveTruncated(131072)).toBeNull();
+  });
+
   it('should return the current save name without extension', () => {
     const { emulator } = createEmulator();
     expect(emulator.getCurrentSaveName()).toBe('testGame.sav');

--- a/gbajs3/src/emulator/mgba/mgba-emulator.tsx
+++ b/gbajs3/src/emulator/mgba/mgba-emulator.tsx
@@ -56,6 +56,7 @@ export type GBAEmulator = {
   getCurrentGameName: () => string | undefined;
   getCurrentRom: () => Uint8Array | null;
   getCurrentSave: () => Uint8Array | null;
+  getCurrentSaveTruncated: (sizeBytes: number) => Uint8Array | null;
   getCurrentSaveName: () => string | undefined;
   getFile: (path: string) => Uint8Array;
   getStat: (path: string) => FS.Stats;
@@ -150,6 +151,9 @@ const filterSaveStates =
     !fileIgnorePaths.includes(saveStateName) &&
     baseSaveStateName &&
     saveStateName.startsWith(baseSaveStateName);
+
+const truncateSave = (save: Uint8Array, sizeBytes: number) =>
+  save.byteLength > sizeBytes ? save.slice(0, sizeBytes) : save;
 
 export const mGBAEmulator = (mGBA: mGBAEmulatorTypeDef): GBAEmulator => {
   const paths = mGBA.filePaths();
@@ -350,6 +354,11 @@ export const mGBAEmulator = (mGBA: mGBAEmulatorTypeDef): GBAEmulator => {
       mGBA.gameName ? mGBA.FS.readFile(mGBA.gameName) : null,
     getCurrentGameName: () => filepathToFileName(mGBA.gameName),
     getCurrentSave: () => (mGBA.saveName ? mGBA.getSave() : null),
+    getCurrentSaveTruncated: (sizeBytes) => {
+      const save = mGBA.saveName ? mGBA.getSave() : null;
+
+      return save ? truncateSave(save, sizeBytes) : null;
+    },
     getCurrentSaveName: () => filepathToFileName(mGBA.saveName),
     getCurrentAutoSaveStatePath: () => mGBA.autoSaveStateName ?? null,
     getFile: (path) => mGBA.FS.readFile(path),


### PR DESCRIPTION
### High Level Details

- see: https://github.com/thenick775/gbajs3/issues/446

- mGBA adds RTC clock information as metadata at the end of the `.sav` file
   - [where its defined](https://github.com/thenick775/mgba/blob/feature/wasm/include/mgba/internal/gba/savedata.h#L87), matching 16 bytes
   - [where its written](https://github.com/thenick775/mgba/blob/feature/wasm/src/gba/savedata.c#L591) at the end of the file
   - this is expected behavior, but can cause problems when importing to emulators like VBA want an exactly 128KiB save file

- adds an option to download a truncated save at 128KiB exactly, default false

### Screenshots

<img width="391" height="844" alt="Screenshot 2026-05-24 at 6 07 19 PM" src="https://github.com/user-attachments/assets/941342d5-335d-4313-b642-7441d061f4aa" />

some samples of different files downloaded as a test:
```bash
% ls
radical-red-4_1.gba	radical-red-4_1.sav	radical-red-4_1.ups
# original before upload
% xxd 'radical-red-4_1.sav' | tail
0001ff70: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff80: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff90: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffa0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffb0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffc0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffd0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffe0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001fff0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00020000: 2605 1202 0038 3940 cfae 026a 0000 0000  &....89@...j....
# downloaded with truncation flag ON
% xxd 'radical-red-4_1_truncated.sav' | tail
0001ff60: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff70: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff80: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff90: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffa0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffb0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffc0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffd0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffe0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001fff0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
# downloaded with truncation flag OFF
% xxd 'radical-red-4_1-raw-untruncated.sav' | tail
0001ff70: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff80: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ff90: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffa0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffb0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffc0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffd0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001ffe0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
0001fff0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00020000: 2605 1202 0038 3940 cfae 026a 0000 0000  &....89@...j....
%
```
