### PR TITLE
fix: react-draggable debug logging in tests

### DIFF
--- a/gbajs3/vite.config.ts
+++ b/gbajs3/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => {
     // Work around react-draggable shipping process.env.DRAGGABLE_DEBUG in the browser bundle.
     // Upstream issue: https://github.com/react-grid-layout/react-draggable/issues/806
     define: {
-      'process.env.DRAGGABLE_DEBUG': 'false'
+      'process.env': {}
     },
     plugins: [
       react({


### PR DESCRIPTION
### High Level Details

- round two
   - see: https://github.com/react-grid-layout/react-draggable/issues/806
- and https://github.com/thenick775/gbajs3/pull/456
   - the fix described above did not prevent logging in vitest, this replacement does